### PR TITLE
added devtools extension support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "path": "0.12.7",
     "react-addons-test-utils": "^15.4.2",
     "react-test-renderer": "^15.5.3",
+    "redux-devtools-extension": "^2.13.2",
     "serve-favicon": "2.4.2",
     "style-loader": "^0.16.1",
     "topojson-client": "3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,14 @@ import { createStore, applyMiddleware } from 'redux'
 import reducer from './routes/Home/reducers'
 import logger from './routes/Home/middlewares/LoggerMiddleware'
 import dataService from './routes/Home/middlewares/DataServiceMiddleware'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 // const store = createStore(reducer)
 const store = createStore(
   reducer,
-  applyMiddleware(logger, dataService)
+  composeWithDevTools(
+    applyMiddleware(logger, dataService)
+  )
 )
 
 render((


### PR DESCRIPTION
with this, we will be able to view the state changes using this chrome extension: https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd

there are several other platforms also, which can be checked here: https://github.com/zalmoxisus/redux-devtools-extension

do you think with this, we can remove logger middleware?

